### PR TITLE
Improved usability

### DIFF
--- a/crates/just-webrtc-signalling/Cargo.toml
+++ b/crates/just-webrtc-signalling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just-webrtc-signalling"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["network-programming", "web-programming", "wasm", "game-development"]

--- a/crates/just-webrtc-signalling/README.md
+++ b/crates/just-webrtc-signalling/README.md
@@ -50,11 +50,11 @@ use just_webrtc_signalling::client::{RtcSignallingClient, SignalSet};
 /// run all client signalling concurrently
 async fn run_peer(server_address: String) -> Result<()> {
     // prepare callback functions
-    let create_offer_fn = Box::new(|remote_id| create_offer(remote_id).boxed_local());
-    let receive_answer_fn = Box::new(|answer_set| receive_answer(answer_set).boxed_local());
-    let local_sig_cplt_fn = Box::new(|remote_id| local_sig_cplt(remote_id).boxed_local());
-    let receive_offer_fn = Box::new(|offer_set| receive_offer(offer_set).boxed_local());
-    let remote_sig_cplt_fn = Box::new(|remote_id| remote_sig_cplt(remote_id).boxed_local());
+    let create_offer_fn = |remote_id| create_offer(remote_id).boxed_local();
+    let receive_answer_fn = |answer_set| receive_answer(answer_set).boxed_local();
+    let local_sig_cplt_fn = |remote_id| local_sig_cplt(remote_id).boxed_local();
+    let receive_offer_fn = |offer_set| receive_offer(offer_set).boxed_local();
+    let remote_sig_cplt_fn = |remote_id| remote_sig_cplt(remote_id).boxed_local();
     // create signalling client
     let mut signalling_client = RtcSignallingClient::connect(
         server_address,

--- a/crates/just-webrtc/Cargo.toml
+++ b/crates/just-webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just-webrtc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["network-programming", "web-programming", "wasm", "game-development"]

--- a/crates/just-webrtc/README.md
+++ b/crates/just-webrtc/README.md
@@ -53,7 +53,7 @@ async fn run_local_peer() -> Result<()> {
     // ... send the offer and the candidates to Peer B via external signalling implementation ...
     let signalling = (offer, candidates);
 
-    // ... receive the answer and candidates from peer via external signalling implementation ...
+    // ... receive the answer and candidates from Peer B via external signalling implementation ...
     let (answer, candidates) = signalling;
 
     // update local peer from received answer and candidates
@@ -100,7 +100,7 @@ async fn run_remote_peer(offer: SessionDescription, candidates: Vec<ICECandidate
     let answer = remote_peer_connection.get_local_description().await.unwrap();
     let candidates = remote_peer_connection.collect_ice_candidates().await?;
 
-    // ... send the answer and the candidates back to Peer B via external signalling implementation ...
+    // ... send the answer and the candidates back to Peer A via external signalling implementation ...
     let _signalling = (answer, candidates);
 
     // remote signalling is complete! we can now wait for a complete connection

--- a/crates/just-webrtc/src/lib.rs
+++ b/crates/just-webrtc/src/lib.rs
@@ -19,7 +19,7 @@ use types::{DataChannelOptions, ICECandidate, ICEServer, PeerConfiguration, Sess
 /// **Platform agnostic WebRTC DataChannel API**
 pub trait DataChannelExt {
     /// Wait for the data channel to become open and ready to transfer data
-    async fn wait_ready(&mut self);
+    async fn wait_ready(&self);
     /// Receive data from the channel
     async fn receive(&mut self) -> Result<Bytes, Error>;
     /// Send data to the channel
@@ -35,7 +35,7 @@ pub trait DataChannelExt {
 /// **Platform agnostic WebRTC PeerConnection API**
 pub trait PeerConnectionExt {
     /// Wait for the peer connection to become connected
-    async fn wait_peer_connected(&mut self);
+    async fn wait_peer_connected(&self);
     /// Receive a data channel from the peer connection
     async fn receive_channel(&mut self) -> Result<Channel, Error>;
     /// Collect all ICE candidates from the peer connection

--- a/crates/just-webrtc/src/platform/native.rs
+++ b/crates/just-webrtc/src/platform/native.rs
@@ -73,7 +73,7 @@ impl Debug for Channel {
 }
 
 impl DataChannelExt for Channel {
-    async fn wait_ready(&mut self) {
+    async fn wait_ready(&self) {
         while !(self.ready_state.take().await) {}
     }
 
@@ -107,7 +107,7 @@ pub struct PeerConnection {
 }
 
 impl PeerConnectionExt for PeerConnection {
-    async fn wait_peer_connected(&mut self) {
+    async fn wait_peer_connected(&self) {
         while self.peer_connection_state.take().await != PeerConnectionState::Connected {}
     }
 

--- a/crates/just-webrtc/src/platform/wasm.rs
+++ b/crates/just-webrtc/src/platform/wasm.rs
@@ -65,7 +65,7 @@ pub struct Channel {
 }
 
 impl DataChannelExt for Channel {
-    async fn wait_ready(&mut self) {
+    async fn wait_ready(&self) {
         while !(self.ready_state.take().await) {}
     }
 
@@ -100,7 +100,7 @@ pub struct PeerConnection {
 }
 
 impl PeerConnectionExt for PeerConnection {
-    async fn wait_peer_connected(&mut self) {
+    async fn wait_peer_connected(&self) {
         while self.peer_connection_state.take().await != PeerConnectionState::Connected {}
     }
 


### PR DESCRIPTION
`just-webrtc`:
* Fixed example comments to refer to correct peers
* Removed unnecessary mutable borrow on `wait_ready` and `wait_peer_connected` methods

`just-webrtc-signalling`:
* Client `run` method now accepts `impl Fn()` callback patterns instead of requiring `Box<dyn Fn()>`

`signalling-peer` example:
* Updated to use non-boxed callbacks on client `run` method
* Improved readability and efficiency by moving to a `RefCell` peer connection sharing method