### PR TITLE
Multiple peers per client and better peer disconnection handling

### DIFF
--- a/crates/just-webrtc-signalling/Cargo.toml
+++ b/crates/just-webrtc-signalling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just-webrtc-signalling"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["network-programming", "web-programming", "wasm", "game-development"]

--- a/crates/just-webrtc-signalling/Cargo.toml
+++ b/crates/just-webrtc-signalling/Cargo.toml
@@ -40,6 +40,8 @@ tonic-build = { version = "0.11.0", default-features = false, features = ["prost
 
 [dev-dependencies]
 anyhow = "1.0"
+pretty_env_logger = "0.5"
+tokio = { version = "1.36", features = ["rt", "macros"] }
 
 [features]
 default = ["server", "server-web", "client"]

--- a/crates/just-webrtc-signalling/Cargo.toml
+++ b/crates/just-webrtc-signalling/Cargo.toml
@@ -28,8 +28,8 @@ tonic-web-wasm-client = { version = "0.5.1", optional = true }    # transport la
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tonic = { version = "0.11.0", default-features = false, features = ["prost", "codegen", "transport", "tls"], optional = true }  # include native transport layer
-tokio-stream = { version = "0.1.14", optional = true }
-tokio = { version = "1.36", features = ["sync"], optional = true }
+flume = { version = "0.11.0", default-features = false, features = ["async"], optional = true }
+async-broadcast = { version = "0.7.0", optional = true }
 async-stream = { version = "0.3.5", optional = true }
 tower-http = { version = "0.4", features = ["cors"], optional = true }
 http = { version = "0.2.12", optional = true }
@@ -45,8 +45,8 @@ anyhow = "1.0"
 default = ["server", "server-web", "client"]
 server = [
     "dep:tonic",
-    "dep:tokio",
-    "dep:tokio-stream",
+    "dep:flume",
+    "dep:async-broadcast",
     "dep:async-stream",
     "dep:log",
     "dep:futures-util",

--- a/crates/just-webrtc-signalling/proto/main.proto
+++ b/crates/just-webrtc-signalling/proto/main.proto
@@ -31,6 +31,11 @@ message AdvertiseRsp {
     PeerId local_peer = 1;
 }
 
+message TeardownReq {
+    PeerId local_peer = 1;
+}
+message TeardownRsp {}
+
 message PeerDiscoverReq {
     PeerId local_peer = 1;
 }
@@ -73,8 +78,10 @@ message AnswerListenerRsp {
 }
 
 service RtcSignalling {
-    // Advertise self as a peer
+    // Advertise a new peer
     rpc Advertise(AdvertiseReq) returns (AdvertiseRsp) {}
+    // Teardown a peer
+    rpc Teardown(TeardownReq) returns (TeardownRsp) {}
     // Discover all peers
     rpc PeerDiscover(PeerDiscoverReq) returns (PeerDiscoverRsp) {}
     // Open stream of peer discoveries

--- a/crates/just-webrtc-signalling/src/client.rs
+++ b/crates/just-webrtc-signalling/src/client.rs
@@ -311,10 +311,10 @@ pub type ReceiveOfferFut<A, C, E> = Pin<Box<dyn Future<Output = Result<SignalSet
 pub type RemoteSigCpltFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
 
 impl RtcSignallingClient {
-    /// Create the client and open connections to the signalling service.
+    /// Configure and create a signalling client
     ///
     /// Returns resulting signalling client
-    pub async fn connect(
+    pub fn new(
         addr: String,
         timeout: Option<Duration>,
         tls_enabled: bool,
@@ -342,8 +342,9 @@ impl RtcSignallingClient {
                 let addr = format!("http://{addr}");
                 tonic::transport::Channel::from_shared(addr)
                     .map_err(|_e| ClientError::InvalidUrl)?
-            };
-            let channel = endpoint.connect().await?;
+            }
+            .connect_timeout(timeout.unwrap_or(DEFAULT_RESPONSE_DEADLINE));
+            let channel = endpoint.connect_lazy();
             crate::pb::rtc_signalling_client::RtcSignallingClient::new(channel)
         };
         #[cfg(target_arch = "wasm32")]

--- a/crates/just-webrtc-signalling/src/client.rs
+++ b/crates/just-webrtc-signalling/src/client.rs
@@ -1,8 +1,11 @@
 //! Just WebRTC Signalling full-mesh client for both `native` and `wasm`
 
-use std::{collections::HashSet, future::Future, pin::Pin, time::Duration};
+extern crate alloc;
 
-use futures_util::{pin_mut, select, stream::FuturesUnordered, FutureExt, StreamExt};
+use core::{fmt::Debug, future::Future, pin::Pin, time::Duration};
+use alloc::collections::BTreeSet;
+
+use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
 use log::{debug, info, trace, warn};
 use tonic::{metadata::MetadataMap, Extensions, Request, Streaming};
 
@@ -12,8 +15,31 @@ use crate::pb::{
     SignalAnswerReq, SignalOffer, SignalOfferReq,
 };
 
-/// Default deadline for gRPC method response
+/// Default deadline for gRPC method response (10 seconds)
 pub const DEFAULT_RESPONSE_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Set of description, candidates and a remote peer ID.
+#[derive(Debug)]
+pub struct SignalSet<D, C> {
+    /// Serializable session description
+    pub desc: D,
+    /// Serializable ICE candidates
+    pub candidates: C,
+    /// Remote peer ID
+    pub remote_id: u64,
+}
+
+/// Signalling state machine states
+enum SignallingState<A, O, C> {
+    PeerListener(Streaming<PeerListenerRsp>, Vec<PeerChange>),
+    OfferListener(Streaming<OfferListenerRsp>, SignalSet<O, C>),
+    AnswerListener(Streaming<AnswerListenerRsp>, SignalSet<A, C>),
+    CreateOffer(SignalSet<O, C>),
+    ReceiveAnswer(u64),
+    LocalSigCplt(u64),
+    ReceiveOffer(SignalSet<A, C>),
+    RemoteSigCplt(u64),
+}
 
 /// Signalling client error
 #[derive(thiserror::Error, Debug)]
@@ -48,31 +74,21 @@ pub enum ClientError {
 /// Just WebRTC client result type
 pub type ClientResult<T> = Result<T, ClientError>;
 
-/// Set of description, candidates and a remote peer ID.
-#[derive(Debug)]
-pub struct SignalSet<D, C> {
-    /// Serializable session description
-    pub desc: D,
-    /// Serializable ICE candidates
-    pub candidates: C,
-    /// Remote peer ID
-    pub remote_id: u64,
-}
-
 /// Private peer listener helper method
-async fn peer_listener_task(
+async fn peer_listener_task<A, O, C>(
     mut listener: Streaming<PeerListenerRsp>,
-) -> ClientResult<(Streaming<PeerListenerRsp>, Vec<PeerChange>)> {
+) -> ClientResult<SignallingState<A, O, C>> {
     if let Some(message) = listener.message().await? {
-        Ok((listener, message.peer_changes))
+        Ok(SignallingState::PeerListener(listener, message.peer_changes))
     } else {
         Err(ClientError::ListenerClosed)
     }
 }
+
 /// Private offer listener helper method
-async fn offer_listener_task<O, C>(
+async fn offer_listener_task<A, O, C>(
     mut listener: Streaming<OfferListenerRsp>,
-) -> ClientResult<(Streaming<OfferListenerRsp>, SignalSet<O, C>)>
+) -> ClientResult<SignallingState<A, O, C>>
 where
     O: serde::de::DeserializeOwned,
     C: serde::de::DeserializeOwned,
@@ -86,7 +102,7 @@ where
                 candidates,
                 remote_id: signal.offerer_id,
             };
-            Ok((listener, offer_set))
+            Ok(SignallingState::OfferListener(listener, offer_set))
         } else {
             trace!("received empty offer message.");
             offer_listener_task(listener).boxed_local().await
@@ -96,9 +112,9 @@ where
     }
 }
 /// Private answer listener helper method
-async fn answer_listener_task<A, C>(
+async fn answer_listener_task<A, O, C>(
     mut listener: Streaming<AnswerListenerRsp>,
-) -> ClientResult<(Streaming<AnswerListenerRsp>, SignalSet<A, C>)>
+) -> ClientResult<SignallingState<A, O, C>>
 where
     A: serde::de::DeserializeOwned,
     C: serde::de::DeserializeOwned,
@@ -112,13 +128,320 @@ where
                 candidates,
                 remote_id: signal.answerer_id,
             };
-            Ok((listener, answer_set))
+            Ok(SignallingState::AnswerListener(listener, answer_set))
         } else {
             trace!("received empty answer message.");
             answer_listener_task(listener).boxed_local().await
         }
     } else {
         Err(ClientError::ListenerClosed)
+    }
+}
+
+/// Return type of externally implemented function creating an offer signal
+///
+/// Future returning the resulting offer signal
+pub type CreateOfferFut<O, C, E> = Pin<Box<dyn Future<Output = Result<SignalSet<O, C>, E>>>>;
+
+/// Return type of externally implemented function receiving an answer signal
+///
+/// Future returning a result with the remote peer id
+pub type ReceiveAnswerFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
+
+/// Return type of externally implemented function handling completion of local signalling
+///
+/// Future returning a result with the remote peer id
+pub type LocalSigCpltFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
+
+/// Return type of externally implemented function receiving an offer signal and returning an answer
+///
+/// Future returning the resulting answer signal
+pub type ReceiveOfferFut<A, C, E> = Pin<Box<dyn Future<Output = Result<SignalSet<A, C>, E>>>>;
+
+/// Return type of externally implemented function handling completion of remote signalling
+///
+/// Returns a result with the remote peer id
+pub type RemoteSigCpltFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
+
+/// Private signalling state machine future
+type SignallingStateFut<A, O, C> = Pin<Box<dyn Future<Output = ClientResult<SignallingState<A, O, C>>>>>;
+/// A Just WebRTC Signalling peer
+pub struct RtcSignallingPeer<A, O, C> {
+    local_id: u64,
+    discovered_peers: BTreeSet<u64>,
+    first_discovery: bool,
+    // wrapped callback functions
+    create_offer_task: Box<dyn Fn(u64) -> SignallingStateFut<A, O, C>>,
+    receive_answer_task: Box<dyn Fn(SignalSet<A, C>) -> SignallingStateFut<A, O, C>>,
+    local_sig_cplt_task: Box<dyn Fn(u64) -> SignallingStateFut<A, O, C>>,
+    receive_offer_task: Box<dyn Fn(SignalSet<O, C>) -> SignallingStateFut<A, O, C>>,
+    remote_sig_cplt_task: Box<dyn Fn(u64) -> SignallingStateFut<A, O, C>>,
+    // queued futures
+    unordered_futs: FuturesUnordered<Pin<Box<dyn Future<Output = ClientResult<SignallingState<A, O, C>>>>>>,
+}
+
+impl<A, O, C> Debug for RtcSignallingPeer<A, O, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RtcSignallingPeer")
+            .field("local_id", &self.local_id)
+            .field("discovered_peers", &self.discovered_peers)
+            .field("first_discovery", &self.first_discovery)
+            .field("unordered_futs", &self.unordered_futs)
+            .finish()
+    }
+}
+
+impl<A, O, C> RtcSignallingPeer<A, O, C>
+where
+    A: serde::Serialize + serde::de::DeserializeOwned + 'static,
+    O: serde::Serialize + serde::de::DeserializeOwned + 'static,
+    C: serde::Serialize + serde::de::DeserializeOwned + 'static,
+{
+    /// Private creation of a signalling peer
+    fn new(
+        local_id: u64,
+        peer_listener: Streaming<PeerListenerRsp>,
+        offer_listener: Streaming<OfferListenerRsp>,
+        answer_listener: Streaming<AnswerListenerRsp>,
+    ) -> Self {
+        let unordered_futs = FuturesUnordered::new();
+        // queue initial listener tasks
+        unordered_futs.push(peer_listener_task(peer_listener).boxed_local());
+        unordered_futs.push(offer_listener_task(offer_listener).boxed_local());
+        unordered_futs.push(answer_listener_task(answer_listener).boxed_local());
+        Self {
+            local_id,
+            discovered_peers: BTreeSet::new(),
+            first_discovery: true,
+            unordered_futs,
+            // default callback tasks
+            create_offer_task: Box::new(|_id| std::future::pending().boxed_local()),
+            receive_answer_task: Box::new(|answer| async move { Ok(SignallingState::ReceiveAnswer(answer.remote_id)) }.boxed_local()),
+            local_sig_cplt_task: Box::new(|id| async move { Ok(SignallingState::LocalSigCplt(id)) }.boxed_local()),
+            receive_offer_task: Box::new(|_offer| std::future::pending().boxed_local()),
+            remote_sig_cplt_task: Box::new(|id| async move { Ok(SignallingState::RemoteSigCplt(id)) }.boxed_local()),
+        }
+    }
+
+    /// Set callback for handling creation of offer signals
+    ///
+    ///
+    /// Default: never resolves, callback must be set for functional client!
+    pub fn set_on_create_offer<E>(
+        &mut self,
+        create_offer_fn: &'static impl Fn(u64) -> CreateOfferFut<O, C, E>,
+    ) -> &mut Self
+    where
+        E: 'static,
+        ClientError: From<E>
+    {
+        // wrap callback
+        self.create_offer_task = Box::new(|id| {
+            let f = create_offer_fn(id);
+            async {
+                let offer = f.await?;
+                Ok(SignallingState::CreateOffer(offer))
+            }.boxed_local()
+        });
+        self
+    }
+    /// Set callback for handling receiving of answer signals
+    ///
+    /// Default: immediately resolves
+    pub fn set_on_receive_answer<E>(
+        &mut self,
+        receive_answer_fn: &'static impl Fn(SignalSet<A, C>) -> ReceiveAnswerFut<E>,
+    ) -> &mut Self
+    where
+        E: 'static,
+        ClientError: From<E>
+    {
+        // wrap callback
+        self.receive_answer_task = Box::new(|answer| async {
+            let remote_id = receive_answer_fn(answer).await?;
+            Ok(SignallingState::ReceiveAnswer(remote_id))
+        }.boxed_local());
+        self
+    }
+    /// Set callback for handling completion of a local (offerer) signalling chain
+    ///
+    /// Default: immediately resolves
+    pub fn set_on_local_sig_cplt<E>(
+        &mut self,
+        local_sig_cplt_fn: &'static impl Fn(u64) -> LocalSigCpltFut<E>,
+    ) -> &mut Self
+    where
+        E: 'static,
+        ClientError: From<E>
+    {
+        self.local_sig_cplt_task = Box::new(|id| {
+            let f = local_sig_cplt_fn(id);
+            async {
+                let id = f.await?;
+                Ok(SignallingState::LocalSigCplt(id))
+            }.boxed_local()
+        });
+        self
+    }
+    /// Set callback for handling receiving of offer signals
+    ///
+    /// Default: never resolves, callback must be set for functional client!
+    pub fn set_on_receive_offer<E>(
+        &mut self,
+        receive_offer_fn: &'static impl Fn(SignalSet<O, C>) ->  ReceiveOfferFut<A, C, E>,
+    ) -> &mut Self
+    where
+        E: 'static,
+        ClientError: From<E>
+    {
+        self.receive_offer_task = Box::new(|offer| {
+            async {
+                let answer = receive_offer_fn(offer).await?;
+                Ok(SignallingState::ReceiveOffer(answer))
+            }.boxed_local()
+        });
+        self
+    }
+    /// Set callback for handling completion of a remote (answerer) signalling chain
+    ///
+    /// Default: immediately resolves
+    pub fn set_on_remote_sig_cplt<E>(
+        &mut self,
+        remote_sig_cplt_fn: &'static impl Fn(u64) -> RemoteSigCpltFut<E>,
+    ) -> &mut Self
+    where
+        E: 'static,
+        ClientError: From<E>
+    {
+        self.remote_sig_cplt_task = Box::new(|id| {
+            let f = remote_sig_cplt_fn(id);
+            async  {
+                let id = f.await?;
+                Ok(SignallingState::RemoteSigCplt(id))
+            }.boxed_local()
+        });
+        self
+    }
+
+
+    /// Step the signalling concurrent state machine for a peer
+    pub async fn step(&mut self, client: &mut RtcSignallingClient) -> ClientResult<()> {
+        let id = self.local_id;
+
+        // await next state completion
+        let state_cplt = self.unordered_futs.next().await.unwrap()?;
+        // match the state, handle, and queue new states
+        match state_cplt {
+            // Start of "local" signalling chain
+            // PeerListener receives a list of remote peers.
+            // On first iteration, for each remote peer, create a local peer connection...
+            SignallingState::PeerListener(listener, peer_changes) => {
+                debug!("peer listener task completed ({id:#016x})");
+                // reset peer listener future
+                self.unordered_futs.push(peer_listener_task(listener).boxed_local());
+                // apply peer changes to discovered peers map
+                for peer_change in peer_changes.iter() {
+                    match peer_change.change() {
+                        Change::PeerChangeAdd => {
+                            if self.discovered_peers.insert(peer_change.id) {
+                                info!("Discovered peer ({:#016x}).", peer_change.id);
+                            } else {
+                                warn!("Rediscovered peer ({:#016x}). Local discovered peers is out of sync!", peer_change.id);
+                            }
+                        },
+                        Change::PeerChangeRemove => {
+                            if self.discovered_peers.remove(&peer_change.id) {
+                                warn!("Remote peer ({:#016x}) dropped by signalling. Existing connections with this peer will dangle.", peer_change.id);
+                            } else {
+                                warn!("Undiscovered remote peer ({:#016x}) dropped by signalling. Local discovered peers is out of sync!", peer_change.id);
+                            }
+                        },
+                    }
+                }
+                // if this is the first discovery
+                // queue creation of offers for each remote peer (creates local peer connections)
+                if self.first_discovery {
+                    self.first_discovery = false;
+                    let create_offer_tasks = peer_changes.iter()
+                        .filter_map(|peer_change|
+                            if peer_change.change() == Change::PeerChangeAdd {
+                                let remote_id = peer_change.id;
+                                info!("starting local signalling chain. (remote: {remote_id:#016x}");
+                                Some((self.create_offer_task)(remote_id))
+                            } else {
+                                None
+                            }
+                        );
+                    self.unordered_futs.extend(create_offer_tasks);
+                }
+            },
+            // Local peer connections generate offers...
+            // Offers are signalled to the remote peers...
+            SignallingState::CreateOffer(offer_set) => {
+                debug!("create offer task completed ({id:#016x})");
+                // perform signalling of offer
+                let remote_id = client.signal_offer(id, offer_set.remote_id, offer_set.desc, offer_set.candidates).await?;
+                debug!("signalling of offer completed ({id:#016x})");
+                info!("offer signalled to peer. (remote peer: {remote_id:#016x})");
+                // do nothing, local signalling chain continues when answer listener receives an answer
+            },
+            // Listen for answers from the remote peers...
+            SignallingState::AnswerListener(listener, answer_set) => {
+                debug!("answer listener task completed ({id:#016x})");
+                // requeue reset answer listener future
+                // queue receive answer
+                self.unordered_futs.extend([
+                    answer_listener_task(listener).boxed_local(),
+                    (self.receive_answer_task)(answer_set),
+                ]);
+            },
+            // We wait to receive answer responses from the remote peers,
+            // Completing a "local" signalling chain.
+            // And starting a local signalling chain complete handler.
+            SignallingState::ReceiveAnswer(remote_id) => {
+                debug!("receive answer task completed ({id:#016x})");
+                info!("local signalling chain complete. (remote peer: {remote_id:#016x})");
+                // queue local signalling complete handler
+                self.unordered_futs.push((self.local_sig_cplt_task)(remote_id));
+            },
+            // Finally, the local signalling chain complete hander exits
+            SignallingState::LocalSigCplt(remote_id) => {
+                debug!("local signalling cplt task completed ({id:#016x})");
+                info!("local signalling handler complete. (remote peer: {remote_id:#016x})");
+            },
+
+            // Start of a "remote" signalling chain
+            // OfferListener receives a remote offer.
+            SignallingState::OfferListener(listener, offer_set) => {
+                debug!("offer listener task completed ({id:#016x})");
+                // requeue offer listener future
+                // queue receive offer
+                self.unordered_futs.extend([
+                    offer_listener_task(listener).boxed_local(),
+                    (self.receive_offer_task)(offer_set),
+                ]);
+            },
+            // This offer is used to create a remote peer connection and generate an answer...
+            // The answer is sent to the remote offerer,
+            // Completing a "remote" signalling chain.
+            // And starting a remote signalling chain complete handler.
+            SignallingState::ReceiveOffer(answer_set) => {
+                debug!("receive offer task completed ({id:#016x})");
+                // perform signalling of answer
+                let remote_id = client.signal_answer(id, answer_set.remote_id, answer_set.desc, answer_set.candidates).await?;
+                debug!("signalling of answer completed ({id:#016x})");
+                trace!("remote signalling chain complete. (remote peer: {remote_id:#016x})");
+                // queue remote signalling complete handler
+                self.unordered_futs.push((self.remote_sig_cplt_task)(remote_id));
+            },
+            // Finally, the remote signalling chain complete handler exits
+            SignallingState::RemoteSigCplt(remote_id) => {
+                debug!("local signalling cplt task completed ({id:#016x})");
+                info!("local signalling handler complete. (remote peer: {remote_id:#016x})");
+            },
+        }
+
+        Ok(())
     }
 }
 
@@ -136,14 +459,15 @@ pub struct RtcSignallingClient {
 
 /// Private helper methods
 impl RtcSignallingClient {
+    /// Private request builder
+    fn build_request<M>(&self, message: M) -> Request<M> {
+        Request::from_parts(self.grpc_metadata.clone(), Extensions::default(), message)
+    }
+
     /// Private advertise helper method
     async fn advertise(&mut self) -> Result<u64, tonic::Status> {
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
-            AdvertiseReq {},
-        );
         debug!("sending advertise request");
+        let request = self.build_request(AdvertiseReq {});
         let response = self.inner.advertise(request).await?;
         let local_id = response.into_inner().local_peer.unwrap().id;
         debug!("received advertise response ({local_id:#016x})");
@@ -151,14 +475,12 @@ impl RtcSignallingClient {
     }
     /// Private peer discover helper method
     async fn _peer_discover(&mut self, id: u64) -> Result<Vec<u64>, tonic::Status> {
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
+        debug!("sending peer discover request ({id:#016x})");
+        let request = self.build_request(
             PeerDiscoverReq {
                 local_peer: Some(PeerId { id }),
             },
         );
-        debug!("sending peer discover request ({id:#016x})");
         let response = self.inner.peer_discover(request).await?;
         debug!("received peer discover response ({id:#016x})");
         Ok(response
@@ -191,14 +513,12 @@ impl RtcSignallingClient {
         &mut self,
         id: u64,
     ) -> Result<Streaming<OfferListenerRsp>, tonic::Status> {
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
+        debug!("sending open offer listener request ({id:#016x})");
+        let request = self.build_request(
             OfferListenerReq {
                 local_peer: Some(PeerId { id }),
             },
         );
-        debug!("sending open offer listener request ({id:#016x})");
         let response = self.inner.open_offer_listener(request).await?;
         debug!("received open offer listener response ({id:#016x})");
         let offer_listener = response.into_inner();
@@ -209,14 +529,12 @@ impl RtcSignallingClient {
         &mut self,
         id: u64,
     ) -> Result<Streaming<AnswerListenerRsp>, tonic::Status> {
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
+        debug!("sending open answer listener request ({id:#016x})");
+        let request = self.build_request(
             AnswerListenerReq {
                 local_peer: Some(PeerId { id }),
             },
         );
-        debug!("sending open answer listener request ({id:#016x})");
         let response = self.inner.open_answer_listener(request).await?;
         debug!("received open answer listener response ({id:#016x})");
         let answer_listener = response.into_inner();
@@ -234,20 +552,18 @@ impl RtcSignallingClient {
         A: serde::Serialize,
         C: serde::Serialize,
     {
+        debug!("sending signal answer request ({id:#016x})");
         let answer_signal = SignalAnswer {
             answerer_id: id,
             candidates: bincode::serialize(&candidates)?,
             answer: bincode::serialize(&answer)?,
         };
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
+        let request = self.build_request(
             SignalAnswerReq {
                 offerer_peer: Some(PeerId { id: remote_id }),
                 answer_signal: Some(answer_signal),
             },
         );
-        debug!("sending signal answer request ({id:#016x})");
         let _response = self.inner.signal_answer(request).await?;
         debug!("received signal answer response ({id:#016x})");
         Ok(remote_id)
@@ -264,75 +580,82 @@ impl RtcSignallingClient {
         O: serde::Serialize,
         C: serde::Serialize,
     {
+        debug!("sending signal offer request ({id:#016x})");
         let offer_signal = SignalOffer {
             offerer_id: id,
             candidates: bincode::serialize(&candidates)?,
             offer: bincode::serialize(&offer)?,
         };
-        let request = Request::from_parts(
-            self.grpc_metadata.clone(),
-            Extensions::default(),
+        let request = self.build_request(
             SignalOfferReq {
                 answerer_peer: Some(PeerId { id: remote_id }),
                 offer_signal: Some(offer_signal),
             },
         );
         // queue signalling of offer
-        debug!("sending signal offer request ({id:#016x})");
         let _response = self.inner.signal_offer(request).await?;
         debug!("received signal offer response ({id:#016x})");
         Ok(remote_id)
     }
 }
 
-/// Return type of externally implemented function creating an offer signal
-///
-/// Future returning the resulting offer signal
-pub type CreateOfferFut<O, C, E> = Pin<Box<dyn Future<Output = Result<SignalSet<O, C>, E>>>>;
+/// Builder of Just WebRTC signalling clients
+#[derive(Debug)]
+pub struct RtcSignallingClientBuilder {
+    timeout: Duration,
+    tls_enabled: bool,
+    domain: Option<String>,
+    tls_ca_pem: Option<String>,
+}
 
-/// Return type of externally implemented function receiving an answer signal
-///
-/// Future returning a result with the remote peer id
-pub type ReceiveAnswerFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
+impl Default for RtcSignallingClientBuilder {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_RESPONSE_DEADLINE,
+            tls_enabled: false,
+            domain: None,
+            tls_ca_pem: None,
+        }
+    }
+}
 
-/// Return type of externally implemented function handling completion of local signalling
-///
-/// Future returning a result with the remote peer id
-pub type LocalSigCpltFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
+impl RtcSignallingClientBuilder {
+    /// Set the request timeout/deadline.
+    ///
+    /// Default: 10 seconds
+    pub fn set_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+    /// Enables TLS with provided domain and CA PEM strings
+    ///
+    /// Default: TLS disabled
+    pub fn set_tls(mut self, domain: String, tls_ca_pem: String) -> Self {
+        self.tls_enabled = true;
+        self.domain = Some(domain);
+        self.tls_ca_pem = Some(tls_ca_pem);
+        self
+    }
 
-/// Return type of externally implemented function receiving an offer signal and returning an answer
-///
-/// Future returning the resulting answer signal
-pub type ReceiveOfferFut<A, C, E> = Pin<Box<dyn Future<Output = Result<SignalSet<A, C>, E>>>>;
-
-/// Return type of externally implemented function handling completion of remote signalling
-///
-/// Returns a result with the remote peer id
-pub type RemoteSigCpltFut<E> = Pin<Box<dyn Future<Output = Result<u64, E>>>>;
-
-impl RtcSignallingClient {
-    /// Configure and create a signalling client
+    /// Create a signalling client from the builder
     ///
     /// Returns resulting signalling client
-    pub fn new(
-        addr: String,
-        timeout: Option<Duration>,
-        tls_enabled: bool,
-        domain: Option<String>,
-        tls_ca_pem: Option<String>,
-    ) -> ClientResult<Self> {
+    pub fn build(&self, addr: String) -> ClientResult<RtcSignallingClient> {
+        let timeout = self.timeout.clone();
         // create an empty temp request to build timeout metadata
         let mut tmp_req = Request::new(());
-        tmp_req.set_timeout(timeout.unwrap_or(DEFAULT_RESPONSE_DEADLINE));
+        tmp_req.set_timeout(timeout.clone());
         // decompose into parts to get complete grpc metadata
         let (grpc_metadata, _, _) = tmp_req.into_parts();
         // create the client
         #[cfg(not(target_arch = "wasm32"))]
         let client = {
-            let endpoint = if domain.is_some() && tls_ca_pem.is_some() && tls_enabled {
-                let ca_certificate = tonic::transport::Certificate::from_pem(tls_ca_pem.unwrap());
+            let endpoint = if self.domain.is_some() && self.tls_ca_pem.is_some() && self.tls_enabled {
+                let domain = self.domain.clone().unwrap();
+                let tls_ca_pem = self.tls_ca_pem.clone().unwrap();
+                let ca_certificate = tonic::transport::Certificate::from_pem(tls_ca_pem);
                 let tls_config = tonic::transport::ClientTlsConfig::new()
-                    .domain_name(domain.unwrap())
+                    .domain_name(domain)
                     .ca_certificate(ca_certificate);
                 let addr = format!("https://{addr}");
                 tonic::transport::Channel::from_shared(addr)
@@ -343,13 +666,13 @@ impl RtcSignallingClient {
                 tonic::transport::Channel::from_shared(addr)
                     .map_err(|_e| ClientError::InvalidUrl)?
             }
-            .connect_timeout(timeout.unwrap_or(DEFAULT_RESPONSE_DEADLINE));
+            .connect_timeout(timeout);
             let channel = endpoint.connect_lazy();
             crate::pb::rtc_signalling_client::RtcSignallingClient::new(channel)
         };
         #[cfg(target_arch = "wasm32")]
         let client = {
-            if domain.is_some() || tls_ca_pem.is_some() {
+            if self.domain.is_some() || self.tls_ca_pem.is_some() {
                 warn!("Signalling client domain/tls settings are ignored! Client TLS is handled by the browser.");
             }
             let addr = if tls_enabled {
@@ -360,168 +683,31 @@ impl RtcSignallingClient {
             let client = tonic_web_wasm_client::Client::new(addr);
             crate::pb::rtc_signalling_client::RtcSignallingClient::new(client)
         };
-        // advertise local peer
-        // return connected client
-        Ok(Self {
+
+        Ok(RtcSignallingClient {
             grpc_metadata,
             inner: client,
         })
     }
+}
 
-    /// Runs the signalling client
+impl RtcSignallingClient {
+    /// Start a new signalling peer
     ///
-    /// Operates the signalling chain:
-    /// advertising self, listening for offers/answers, discovering peers, and performing offer/answer signalling.
-    ///
-    /// The externally provided callback functions are called concurrently on the local thread.
-    pub async fn run<A, O, C, E>(
-        &mut self,
-        create_offer_fn: impl Fn(u64) -> CreateOfferFut<O, C, E>,
-        receive_answer_fn: impl Fn(SignalSet<A, C>) -> ReceiveAnswerFut<E>,
-        local_sig_cplt_fn: impl Fn(u64) -> LocalSigCpltFut<E>,
-        receive_offer_fn: impl Fn(SignalSet<O, C>) -> ReceiveOfferFut<A, C, E>,
-        remote_sig_cplt_fn: impl Fn(u64) -> RemoteSigCpltFut<E>,
-    ) -> ClientResult<()>
+    /// Connects the peer and returns [`RtcSignallingPeer`]
+    pub async fn start_peer<A, O, C>(
+        &mut self
+    ) -> ClientResult<RtcSignallingPeer<A, O, C>>
     where
-        A: serde::Serialize + serde::de::DeserializeOwned,
-        O: serde::Serialize + serde::de::DeserializeOwned,
-        C: serde::Serialize + serde::de::DeserializeOwned,
-        ClientError: From<E>,
+        A: serde::Serialize + serde::de::DeserializeOwned + 'static,
+        O: serde::Serialize + serde::de::DeserializeOwned + 'static,
+        C: serde::Serialize + serde::de::DeserializeOwned + 'static,
     {
-        let id = self.advertise().await?;
-        let peer_listener = self.open_peer_listener(id).await?;
-        let offer_listener = self.open_offer_listener(id).await?;
-        let answer_listener = self.open_answer_listener(id).await?;
-        // create futures to run initially
-        let peer_listener_fut = peer_listener_task(peer_listener).fuse();
-        let offer_listener_fut = offer_listener_task(offer_listener).fuse();
-        let answer_listener_fut = answer_listener_task(answer_listener).fuse();
-        pin_mut!(peer_listener_fut, offer_listener_fut, answer_listener_fut);
-        // create empty sets of futures to run later
-        let mut create_offer_futs = FuturesUnordered::new();
-        let mut receive_answer_futs = FuturesUnordered::new();
-        let mut local_sig_cplt_futs = FuturesUnordered::new();
-        let mut receive_offer_futs = FuturesUnordered::new();
-        let mut remote_sig_cplt_futs = FuturesUnordered::new();
-        // init empty list of discovered peers
-        let mut discovered_peers: HashSet<u64> = HashSet::new();
-        let mut first_discovery = true;
-        debug!("signalling loop start");
-        // concurrent signalling loop
-        loop {
-            select! {
-                // Start of "local" signalling chain
-                // PeerListener receives a list of remote peers.
-                // On first iteration, for each remote peer, create a local peer connection...
-                result = peer_listener_fut => {
-                    let (listener, peer_changes) = result?;
-                    debug!("peer listener task completed ({id:#016x})");
-                    // reset peer listener future
-                    peer_listener_fut.set(peer_listener_task(listener).fuse());
-                    // apply peer changes to discovered peers map
-                    for peer_change in peer_changes.iter() {
-                        match peer_change.change() {
-                            Change::PeerChangeAdd => {
-                                if discovered_peers.insert(peer_change.id) {
-                                    info!("Discovered peer ({:#016x}).", peer_change.id);
-                                } else {
-                                    warn!("Rediscovered peer ({:#016x}). Local discovered peers is out of sync!", peer_change.id);
-                                }
-                            },
-                            Change::PeerChangeRemove => {
-                                if discovered_peers.remove(&peer_change.id) {
-                                    warn!("Remote peer ({:#016x}) dropped by signalling. Existing connections with this peer will dangle.", peer_change.id);
-                                } else {
-                                    warn!("Undiscovered remote peer ({:#016x}) dropped by signalling. Local discovered peers is out of sync!", peer_change.id);
-                                }
-                            },
-                        }
-                    }
-                    // if this is the first discovery, queue creation of offers for each remote peer (creates local peer connections)
-                    if first_discovery {
-                        first_discovery = false;
-                        let create_offer_tasks = peer_changes.iter()
-                            .filter_map(|peer_change|
-                                if peer_change.change() == Change::PeerChangeAdd {
-                                    let remote_id = peer_change.id;
-                                    info!("starting local signalling chain. (remote: {remote_id:#016x}");
-                                    Some(create_offer_fn(remote_id))
-                                } else {
-                                    None
-                                }
-                            );
-                        create_offer_futs.extend(create_offer_tasks);
-                    }
-                },
-                // Local peer connections generate offers...
-                // Offers are signalled to the remote peers...
-                result = create_offer_futs.select_next_some() => {
-                    debug!("create offer task completed ({id:#016x})");
-                    let offer_set = result?;
-                    // perform signalling of offer
-                    let remote_id = self.signal_offer(id, offer_set.remote_id, offer_set.desc, offer_set.candidates).await?;
-                    debug!("signalling of offer completed ({id:#016x})");
-                    info!("offer signalled to peer. (remote peer: {remote_id:#016x})");
-                    // do nothing, local signalling chain continues when answer listener receives an answer
-                },
-                // Listen for answers from the remote peers...
-                result = answer_listener_fut => {
-                    let (listener, answer_set) = result?;
-                    debug!("answer listener task completed ({id:#016x})");
-                    // reset answer listener future
-                    answer_listener_fut.set(answer_listener_task(listener).fuse());
-                    // queue receive answer
-                    receive_answer_futs.push(receive_answer_fn(answer_set));
-                },
-                // We wait to receive answer responses from the remote peers,
-                // Completing a "local" signalling chain.
-                // And start a local signalling chain complete handler.
-                result = receive_answer_futs.select_next_some() => {
-                    let remote_id = result?;
-                    debug!("receive answer task completed ({id:#016x})");
-                    info!("local signalling chain complete. (remote peer: {remote_id:#016x})");
-                    // queue local signalling complete handler
-                    local_sig_cplt_futs.push(local_sig_cplt_fn(remote_id));
-                },
-                // Finally, the local signalling chain complete hander exits
-                result = local_sig_cplt_futs.select_next_some() => {
-                    let remote_id = result?;
-                    info!("local signalling handler complete. (remote peer: {remote_id:#016x})");
-                },
-
-                // Start of a "remote" signalling chain
-                // OfferListener receives a remote offer.
-                result = offer_listener_fut => {
-                    let (listener, offer_set) = result?;
-                    debug!("offer listener task completed ({id:#016x})");
-                    // reset offer listener future
-                    offer_listener_fut.set(offer_listener_task(listener).fuse());
-                    // queue receive offer
-                    receive_offer_futs.push(receive_offer_fn(offer_set));
-                },
-                // This offer is used to create a remote peer connection and generate an answer...
-                // The answer is sent to the remote offerer,
-                // Completing a "remote" signalling chain.
-                // And starting a remote signalling chain complete handler.
-                result = receive_offer_futs.select_next_some() => {
-                    debug!("receive offer task completed ({id:#016x})");
-                    let answer_set = result?;
-                    // perform signalling of answer
-                    let remote_id = self.signal_answer(id, answer_set.remote_id, answer_set.desc, answer_set.candidates).await?;
-                    debug!("signalling of answer completed ({id:#016x})");
-                    trace!("remote signalling chain complete. (remote peer: {remote_id:#016x})");
-                    // queue remote signalling complete handler
-                    remote_sig_cplt_futs.push(remote_sig_cplt_fn(remote_id));
-                },
-                // Finally, the remote signalling chain complete handler exits
-                result = remote_sig_cplt_futs.select_next_some() => {
-                    let remote_id = result?;
-                    info!("remote signalling handler complete. (remote peer: {remote_id:#016x})");
-                },
-                complete => break,
-            }
-        }
-
-        Ok(())
+        let local_id = self.advertise().await?;
+        let peer_listener = self.open_peer_listener(local_id).await?;
+        let offer_listener = self.open_offer_listener(local_id).await?;
+        let answer_listener = self.open_answer_listener(local_id).await?;
+        let signalling_peer = RtcSignallingPeer::new(local_id, peer_listener, offer_listener, answer_listener);
+        Ok(signalling_peer)
     }
 }

--- a/crates/just-webrtc-signalling/src/server.rs
+++ b/crates/just-webrtc-signalling/src/server.rs
@@ -182,7 +182,6 @@ impl RtcSignalling for RtcSignallingService {
         &self,
         request: Request<SignalOfferReq>,
     ) -> Result<Response<SignalOfferRsp>> {
-        debug!("check");
         let message = request.into_inner();
         let answerer_peer = message
             .answerer_peer

--- a/crates/just-webrtc-signalling/tests/signalling.rs
+++ b/crates/just-webrtc-signalling/tests/signalling.rs
@@ -1,0 +1,85 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::Result;
+use just_webrtc_signalling::{client::RtcSignallingClientBuilder, server::{serve, Signalling}, DEFAULT_NATIVE_SERVER_ADDR};
+
+const PHONY_OFFER: &str = "offer";
+const PHONY_OFFERER_CANDIDATES: &str = "offerer candidates";
+const PHONY_ANSWER: &str = "answer";
+const PHONY_ANSWER_CANDIDATES: &str = "answerer candidates";
+
+async fn run_peer(local: bool) -> Result<()> {
+
+    static LOCAL_SIGNALLING_COMPLETE: AtomicBool = AtomicBool::new(false);
+    static REMOTE_SIGNALLING_COMPLETE: AtomicBool = AtomicBool::new(false);
+
+    // create offer testing callback
+    async fn create_offer(remote_id: u64) -> Result<(u64, (String, String))> {
+        Ok((remote_id, (PHONY_OFFER.to_string(), PHONY_OFFERER_CANDIDATES.to_string())))
+    }
+    // receive answer testing callback
+    async fn receive_answer(remote_id: u64, answer_set: (String, String)) -> Result<u64> {
+        assert_eq!(&answer_set.0, PHONY_ANSWER);
+        assert_eq!(&answer_set.1, PHONY_ANSWER_CANDIDATES);
+        Ok(remote_id)
+    }
+    // local signalling complete testing callback
+    async fn local_sig_cplt(remote_id: u64) -> Result<u64> {
+        LOCAL_SIGNALLING_COMPLETE.store(true, Ordering::Relaxed);
+        Ok(remote_id)
+    }
+    // receive offer testing callback
+    async fn receive_offer(remote_id: u64, offer_set: (String, String)) -> Result<(u64, (String, String))> {
+        assert_eq!(&offer_set.0, PHONY_OFFER);
+        assert_eq!(&offer_set.1, PHONY_OFFERER_CANDIDATES);
+        Ok((remote_id, (PHONY_ANSWER.to_string(), PHONY_ANSWER_CANDIDATES.to_string())))
+    }
+    // remote signalling complete testing callback
+    async fn remote_sig_cplt(remote_id: u64) -> Result<u64> {
+        REMOTE_SIGNALLING_COMPLETE.store(true, Ordering::Relaxed);
+        Ok(remote_id)
+    }
+
+    // build signalling client
+    let signalling_client = RtcSignallingClientBuilder::default()
+        .build(DEFAULT_NATIVE_SERVER_ADDR.to_string())?;
+    let signalling_client = signalling_client;
+    // start peer
+    let mut signalling_peer = signalling_client.start_peer::<String, String, String>().await?;
+    // set callbacks
+    signalling_peer.set_on_create_offer(create_offer);
+    signalling_peer.set_on_receive_answer(receive_answer);
+    signalling_peer.set_on_local_sig_cplt(local_sig_cplt);
+    signalling_peer.set_on_receive_offer(receive_offer);
+    signalling_peer.set_on_remote_sig_cplt(remote_sig_cplt);
+    // run signalling peer
+    loop {
+        if local && LOCAL_SIGNALLING_COMPLETE.load(Ordering::Relaxed) {
+            return Ok(())
+        } else if !local && REMOTE_SIGNALLING_COMPLETE.load(Ordering::Relaxed) {
+            return Ok(())
+        }
+        signalling_peer.step().await?;
+    }
+}
+
+#[cfg(all(feature = "server", feature = "client"))]
+#[tokio::test]
+async fn test_signalling() -> Result<()> {
+    use std::sync::Arc;
+    pretty_env_logger::try_init()?;
+
+    let signalling = Arc::new(Signalling::new());
+    // start server
+    let server_handle = tokio::spawn(serve(signalling, DEFAULT_NATIVE_SERVER_ADDR.parse()?, None, None, None));
+    // start peers A (local) & B (remote)
+    let peer_a_fut = run_peer(true);
+    let peer_b_fut = run_peer(false);
+    // try run both peers to completion
+    tokio::try_join!(peer_a_fut, peer_b_fut)?;
+    // grab any error from server handle
+    if server_handle.is_finished() {
+        server_handle.await??;
+    }
+    Ok(())
+}

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -213,7 +213,7 @@ async fn run_peer(addr: &str) -> Result<()> {
     };
     // create signalling client
     let mut signalling_client =
-        RtcSignallingClient::connect(addr.to_string(), None, false, None, None).await?;
+        RtcSignallingClient::new(addr.to_string(), None, false, None, None)?;
     // run signalling client
     signalling_client
         .run(

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -202,7 +202,7 @@ async fn run_peer(addr: &str) -> Result<()> {
     };
 
     // build signalling client
-    let mut signalling_client = RtcSignallingClientBuilder::default()
+    let signalling_client = RtcSignallingClientBuilder::default()
         .build(addr.to_string())?;
     let mut signalling_peer = signalling_client.start_peer().await?;
     // set callbacks
@@ -215,7 +215,7 @@ async fn run_peer(addr: &str) -> Result<()> {
 
     // run signalling peer
     loop {
-        signalling_peer.step(&mut signalling_client).await?;
+        signalling_peer.step().await?;
     }
 }
 

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -56,7 +56,7 @@ async fn peer_echo_task(remote_id: u64, mut peer_connection: PeerConnection) -> 
 
 async fn create_offer() -> Result<((SessionDescription, Vec<ICECandidate>), PeerConnection)> {
     let channel_options = vec![(
-        format!("example_channel_"),
+        "example_channel_".to_string(),
         DataChannelOptions::default(),
     )];
     let mut local_peer_connection = PeerConnectionBuilder::new()
@@ -96,12 +96,8 @@ async fn receive_answer(
     local_peer_connection: &PeerConnection,
 ) -> Result<()> {
     // set answer description and add candidates
-    local_peer_connection
-        .set_remote_description(answer)
-        .await?;
-    local_peer_connection
-        .add_ice_candidates(candidates)
-        .await?;
+    local_peer_connection.set_remote_description(answer).await?;
+    local_peer_connection.add_ice_candidates(candidates).await?;
     Ok(())
 }
 
@@ -153,7 +149,7 @@ async fn run_peer(addr: &str) -> Result<()> {
             let (offer_set, local_peer_connection) = create_offer().await?;
             peer_connections
                 .borrow_mut()
-                .insert(remote_id.clone(), local_peer_connection)?;
+                .insert(remote_id, local_peer_connection)?;
             Ok::<_, anyhow::Error>((remote_id, offer_set))
         }
     };
@@ -187,7 +183,7 @@ async fn run_peer(addr: &str) -> Result<()> {
             let (answer_set, remote_peer_connection) = receive_offer(offer, candidates).await?;
             peer_connections
                 .borrow_mut()
-                .insert(remote_id.clone(), remote_peer_connection)?;
+                .insert(remote_id, remote_peer_connection)?;
             Ok::<_, anyhow::Error>((remote_id, answer_set))
         }
     };
@@ -202,8 +198,7 @@ async fn run_peer(addr: &str) -> Result<()> {
     };
 
     // build signalling client
-    let signalling_client = RtcSignallingClientBuilder::default()
-        .build(addr.to_string())?;
+    let signalling_client = RtcSignallingClientBuilder::default().build(addr.to_string())?;
     let mut signalling_peer = signalling_client.start_peer().await?;
     // set callbacks
     signalling_peer

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
 
 use anyhow::{anyhow, Result};
-use futures_util::{FutureExt, StreamExt};
+use futures_util::StreamExt;
 use log::info;
 
 use just_webrtc::{
@@ -9,13 +9,10 @@ use just_webrtc::{
     types::{DataChannelOptions, ICECandidate, SessionDescription},
     DataChannelExt, PeerConnectionBuilder, PeerConnectionExt,
 };
-use just_webrtc_signalling::client::RtcSignallingClient;
+use just_webrtc_signalling::client::RtcSignallingClientBuilder;
 
 const ECHO_REQUEST: &str = "I'm literally Ryan Gosling.";
 const ECHO_RESPONSE: &str = "I know right! He's literally me.";
-
-// fill signal set generics
-type SignalSet = just_webrtc_signalling::client::SignalSet<SessionDescription, Vec<ICECandidate>>;
 
 async fn peer_echo_task(remote_id: u64, mut peer_connection: PeerConnection) -> Result<u64> {
     info!("started peer echo task. ({remote_id})");
@@ -57,9 +54,9 @@ async fn peer_echo_task(remote_id: u64, mut peer_connection: PeerConnection) -> 
     }
 }
 
-async fn create_offer(remote_id: u64) -> Result<(SignalSet, PeerConnection)> {
+async fn create_offer() -> Result<((SessionDescription, Vec<ICECandidate>), PeerConnection)> {
     let channel_options = vec![(
-        format!("rtc_channel_to_{remote_id:#016x}_"),
+        format!("example_channel_"),
         DataChannelOptions::default(),
     )];
     let mut local_peer_connection = PeerConnectionBuilder::new()
@@ -71,49 +68,41 @@ async fn create_offer(remote_id: u64) -> Result<(SignalSet, PeerConnection)> {
         .await
         .ok_or(anyhow!("could not get local description!"))?;
     let candidates = local_peer_connection.collect_ice_candidates().await?;
-    let signal = SignalSet {
-        desc: offer,
-        candidates,
-        remote_id,
-    };
-    Ok((signal, local_peer_connection))
+    Ok(((offer, candidates), local_peer_connection))
 }
 
-async fn receive_offer(offer_set: SignalSet) -> Result<(SignalSet, PeerConnection)> {
+async fn receive_offer(
+    offer: SessionDescription,
+    candidates: Vec<ICECandidate>,
+) -> Result<((SessionDescription, Vec<ICECandidate>), PeerConnection)> {
     let mut remote_peer_connection = PeerConnectionBuilder::new()
-        .with_remote_offer(Some(offer_set.desc))?
+        .with_remote_offer(Some(offer))?
         .build()
         .await?;
     remote_peer_connection
-        .add_ice_candidates(offer_set.candidates)
+        .add_ice_candidates(candidates)
         .await?;
     let answer = remote_peer_connection
         .get_local_description()
         .await
         .ok_or(anyhow!("could not get remote description!"))?;
     let candidates = remote_peer_connection.collect_ice_candidates().await?;
-    let remote_id = offer_set.remote_id;
-    let answer_set = SignalSet {
-        desc: answer,
-        candidates,
-        remote_id,
-    };
-    Ok((answer_set, remote_peer_connection))
+    Ok(((answer, candidates), remote_peer_connection))
 }
 
 async fn receive_answer(
-    answer_set: SignalSet,
-    local_peer_connection: PeerConnection,
-) -> Result<(u64, PeerConnection)> {
-    let remote_id = answer_set.remote_id;
+    answer: SessionDescription,
+    candidates: Vec<ICECandidate>,
+    local_peer_connection: &PeerConnection,
+) -> Result<()> {
     // set answer description and add candidates
     local_peer_connection
-        .set_remote_description(answer_set.desc)
+        .set_remote_description(answer)
         .await?;
     local_peer_connection
-        .add_ice_candidates(answer_set.candidates)
+        .add_ice_candidates(candidates)
         .await?;
-    Ok((remote_id, local_peer_connection))
+    Ok(())
 }
 
 /// Peer connection map for passing connections between callback functions
@@ -156,75 +145,78 @@ async fn run_peer(addr: &str) -> Result<()> {
     // create locally shared peer connections map
     let peer_connections: Rc<RefCell<PeerConnectionMap>> =
         Rc::new(RefCell::new(PeerConnectionMap::default()));
-    // prepare create offer callback function
-    let create_offer_fn = |remote_id| {
-        let peer_connections = peer_connections.clone();
+    // prepare create offer callback closure
+    let peer_connections_offer = peer_connections.clone();
+    let create_offer_fn = move |remote_id: u64| {
+        let peer_connections = peer_connections_offer.clone();
         async move {
-            let (offer, local_peer_connection) = create_offer(remote_id).await?;
+            let (offer_set, local_peer_connection) = create_offer().await?;
             peer_connections
                 .borrow_mut()
-                .insert(remote_id, local_peer_connection)?;
-            Ok(offer)
+                .insert(remote_id.clone(), local_peer_connection)?;
+            Ok::<_, anyhow::Error>((remote_id, offer_set))
         }
-        .boxed_local()
     };
-    // prepare receive answer callback function
-    let receive_answer_fn = |answer_set: SignalSet| {
-        let peer_connections = peer_connections.clone();
+    // prepare receive answer callback closure
+    let peer_connections_answer = peer_connections.clone();
+    let receive_answer_fn = move |remote_id, (answer, candidates)| {
+        let peer_connections = peer_connections_answer.clone();
         async move {
-            let peer_connection = peer_connections.borrow_mut().take(&answer_set.remote_id)?;
-            let (remote_id, peer_connection) = receive_answer(answer_set, peer_connection).await?;
+            let peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
+            receive_answer(answer, candidates, &peer_connection).await?;
             peer_connections
                 .borrow_mut()
                 .place(&remote_id, peer_connection)?;
-            Ok(remote_id)
+            Ok::<_, anyhow::Error>(remote_id)
         }
-        .boxed_local()
     };
-    // prepare local signalling complete callback function
-    let local_sig_cplt_fn = |remote_id| {
-        let peer_connections = peer_connections.clone();
+    // prepare local signalling complete callback closure
+    let peer_connections_local = peer_connections.clone();
+    let local_sig_cplt_fn = move |remote_id| {
+        let peer_connections = peer_connections_local.clone();
         async move {
             let local_peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
             peer_echo_task(remote_id, local_peer_connection).await
         }
-        .boxed_local()
     };
-    // prepare receive offer callback function
-    let receive_offer_fn = |offer_set| {
-        let peer_connections = peer_connections.clone();
+    // prepare receive offer callback closure
+    let peer_connections_offer = peer_connections.clone();
+    let receive_offer_fn = move |remote_id: u64, (offer, candidates)| {
+        let peer_connections = peer_connections_offer.clone();
         async move {
-            let (answer, remote_peer_connection) = receive_offer(offer_set).await?;
+            let (answer_set, remote_peer_connection) = receive_offer(offer, candidates).await?;
             peer_connections
                 .borrow_mut()
-                .insert(answer.remote_id, remote_peer_connection)?;
-            Ok(answer)
+                .insert(remote_id.clone(), remote_peer_connection)?;
+            Ok::<_, anyhow::Error>((remote_id, answer_set))
         }
-        .boxed_local()
     };
-    // prepare remote signalling complete callback function
-    let remote_sig_cplt_fn = |remote_id| {
-        let peer_connections = peer_connections.clone();
+    // prepare remote signalling complete callback closure
+    let peer_connections_remote = peer_connections.clone();
+    let remote_sig_cplt_fn = move |remote_id| {
+        let peer_connections = peer_connections_remote.clone();
         async move {
             let remote_peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
             peer_echo_task(remote_id, remote_peer_connection).await
         }
-        .boxed_local()
     };
-    // create signalling client
-    let mut signalling_client =
-        RtcSignallingClient::new(addr.to_string(), None, false, None, None)?;
-    // run signalling client
-    signalling_client
-        .run(
-            create_offer_fn,
-            receive_answer_fn,
-            local_sig_cplt_fn,
-            receive_offer_fn,
-            remote_sig_cplt_fn,
-        )
-        .await?;
-    Ok(())
+
+    // build signalling client
+    let mut signalling_client = RtcSignallingClientBuilder::default()
+        .build(addr.to_string())?;
+    let mut signalling_peer = signalling_client.start_peer().await?;
+    // set callbacks
+    signalling_peer
+        .set_on_create_offer(create_offer_fn)
+        .set_on_receive_answer(receive_answer_fn)
+        .set_on_local_sig_cplt(local_sig_cplt_fn)
+        .set_on_receive_offer(receive_offer_fn)
+        .set_on_remote_sig_cplt(remote_sig_cplt_fn);
+
+    // run signalling peer
+    loop {
+        signalling_peer.step(&mut signalling_client).await?;
+    }
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
API changes and improvements to `just-webrtc-signalling` (breaking):
* Server now uses `flume` and `async-broadcast` channels for performance and to remote the `tokio` dependency.
* Client gRPC connections are now lazy initiated on both `wasm` and `native`
* Introduced `RtcSignallingClientBuilder` for configuration and building clients
* New `RtcSignallingPeer` enables multiple peers per client
* `RtcSignallingPeer` uses revamped concurrent state machine (`RtcSignallingPeer::step`), improved from the old `RtcSignallingClient::run`.
* Peers can now be "torn down" when finished, providing a clean peer disconnection option.
* Dirty peer disconnections are now detected on both client and server and handled appropriately.
* Several improvements/clean-ups on the client-side API