### PR TITLE
Expose `PeerConnectionState` for monitoring

### DIFF
--- a/crates/just-webrtc-signalling/Cargo.toml
+++ b/crates/just-webrtc-signalling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just-webrtc-signalling"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["network-programming", "web-programming", "wasm", "game-development"]
@@ -14,29 +14,29 @@ readme = "README.md"
 exclude = [".git*"]
 
 [dependencies]
-prost = "0.12.3"
+prost = "0.13"
 log = { version = "0.4", optional = true }
 thiserror = { version = "1.0", optional = true }
 anyhow = { version = "1.0", optional = true }
 bincode = { version = "1.3", optional = true }
-futures-util = { version = "0.3.30", optional = true }
+futures-util = { version = "0.3", optional = true }
 serde = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tonic = { version = "0.11.0", default-features = false, features = ["prost", "codegen"], optional = true } # no included transport layer
-tonic-web-wasm-client = { version = "0.5.1", optional = true }    # transport layer for tonic clients over WASM
+tonic = { version = "0.12", default-features = false, features = ["prost", "codegen"], optional = true } # no included transport layer
+tonic-web-wasm-client = { version = "0.6", optional = true }    # transport layer for tonic clients over WASM
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tonic = { version = "0.11.0", default-features = false, features = ["prost", "codegen", "transport", "tls"], optional = true }  # include native transport layer
-flume = { version = "0.11.0", default-features = false, features = ["async"], optional = true }
+tonic = { version = "0.12", default-features = false, features = ["prost", "codegen", "transport", "tls"], optional = true }  # include native transport layer
+flume = { version = "0.11", default-features = false, features = ["async"], optional = true }
 async-broadcast = { version = "0.7.0", optional = true }
 async-stream = { version = "0.3.5", optional = true }
-tower-http = { version = "0.4", features = ["cors"], optional = true }
-http = { version = "0.2.12", optional = true }
-tonic-web = { version = "0.11.0", optional = true }
+tower-http = { version = "0.6", features = ["cors"], optional = true }
+http = { version = "1.1", optional = true }
+tonic-web = { version = "0.12", optional = true }
 
 [build-dependencies]
-tonic-build = { version = "0.11.0", default-features = false, features = ["prost", "transport"] } # transport is disabled for wasm within build script
+tonic-build = { version = "0.12", default-features = false, features = ["prost", "transport"] } # transport is disabled for wasm within build script
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/just-webrtc-signalling/README.md
+++ b/crates/just-webrtc-signalling/README.md
@@ -15,7 +15,7 @@ This signalling implementation is built around a [`tonic`](https://github.com/hy
 
 ```toml
 [dependencies]
-just-webrtc-signalling = "0.1"
+just-webrtc-signalling = "0.2"
 ```
 
 ## Documentation

--- a/crates/just-webrtc-signalling/README.md
+++ b/crates/just-webrtc-signalling/README.md
@@ -152,4 +152,5 @@ async fn serve() -> Result<()> {
 This project is licensed under either of
 * [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [MIT License](https://opensource.org/licenses/MIT)
+
 at your option.

--- a/crates/just-webrtc-signalling/build.rs
+++ b/crates/just-webrtc-signalling/build.rs
@@ -9,6 +9,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("proto file should reside in a directory");
     tonic_build::configure()
         .build_transport(target != "wasm32-unknown-unknown")
-        .compile(&[proto_path], &[proto_dir])?;
+        .compile_protos(&[proto_path], &[proto_dir])?;
     Ok(())
 }

--- a/crates/just-webrtc-signalling/src/client.rs
+++ b/crates/just-webrtc-signalling/src/client.rs
@@ -1,19 +1,15 @@
 //! Just WebRTC Signalling full-mesh client for both `native` and `wasm`
 
-extern crate alloc;
-
-use alloc::collections::BTreeSet;
-use core::{fmt::Debug, future::Future, pin::Pin, time::Duration};
-
-use futures_util::{lock::Mutex, stream::FuturesUnordered, FutureExt, StreamExt};
-use log::{debug, info, trace, warn};
-use tonic::{metadata::MetadataMap, Extensions, Request, Streaming};
-
 use crate::pb::{
     AdvertiseReq, AnswerListenerReq, AnswerListenerRsp, Change, OfferListenerReq, OfferListenerRsp,
     PeerChange, PeerDiscoverReq, PeerId, PeerListenerReq, PeerListenerRsp, SignalAnswer,
     SignalAnswerReq, SignalOffer, SignalOfferReq, TeardownReq,
 };
+use alloc::collections::BTreeSet;
+use core::{fmt::Debug, future::Future, pin::Pin, time::Duration};
+use futures_util::{lock::Mutex, stream::FuturesUnordered, FutureExt, StreamExt};
+use log::{debug, info, trace, warn};
+use tonic::{metadata::MetadataMap, Extensions, Request, Streaming};
 
 /// Default deadline for gRPC method response (10 seconds)
 pub const DEFAULT_RESPONSE_DEADLINE: Duration = Duration::from_secs(10);

--- a/crates/just-webrtc-signalling/src/lib.rs
+++ b/crates/just-webrtc-signalling/src/lib.rs
@@ -7,6 +7,8 @@
 #[cfg(all(target_arch = "wasm32", feature = "server"))]
 compile_error!("feature \"server\" is not compatible with target \"wasm32\"");
 
+extern crate alloc;
+
 use prost as _;
 
 #[cfg(any(feature = "client", feature = "server"))]

--- a/crates/just-webrtc-signalling/src/server.rs
+++ b/crates/just-webrtc-signalling/src/server.rs
@@ -1,25 +1,20 @@
 //! Just WebRTC Signalling full-mesh server/services
 
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    pin::Pin,
-    sync::{atomic::AtomicU64, Arc, OnceLock, RwLock},
-    time::Duration,
-};
-
-use futures_util::{Stream, StreamExt};
-use log::{debug, info, warn};
-
-use tonic::{Request, Response, Result, Status};
-
+use crate::pb::rtc_signalling_server::{RtcSignalling, RtcSignallingServer};
 use crate::pb::{
-    rtc_signalling_server::{RtcSignalling, RtcSignallingServer},
     AdvertiseReq, AdvertiseRsp, AnswerListenerReq, AnswerListenerRsp, OfferListenerReq,
     OfferListenerRsp, PeerChange, PeerDiscoverReq, PeerDiscoverRsp, PeerId, PeerListenerReq,
     PeerListenerRsp, SignalAnswerReq, SignalAnswerRsp, SignalOfferReq, SignalOfferRsp, TeardownReq,
     TeardownRsp,
 };
+use futures_util::{Stream, StreamExt};
+use log::{debug, info, warn};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::{atomic::AtomicU64, Arc, OnceLock, RwLock};
+use std::time::Duration;
+use tonic::{Request, Response, Result, Status};
 
 static GENERATOR: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/just-webrtc/Cargo.toml
+++ b/crates/just-webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "just-webrtc"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["network-programming", "web-programming", "wasm", "game-development"]
@@ -16,16 +16,17 @@ exclude = [".git*"]
 [dependencies]
 bytes = "1.5"
 serde = "1.0"
-log = "0.4.20"
+log = "0.4"
 thiserror = "1.0"
-async_cell = "0.2.2"
+async_cell = "0.2"
+flume = { version = "0.11", default-features = false, features = ["async"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.68"
-wasm-bindgen = "0.2.91"
-serde-wasm-bindgen = "0.6.3"
-wasm-bindgen-futures = "0.4.42"
-web-sys = { version = "0.3.68", default-features = false, features = [
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", default-features = false, features = [
   "MessageEvent",
   "RtcBundlePolicy",
   "RtcConfiguration",
@@ -45,16 +46,14 @@ web-sys = { version = "0.3.68", default-features = false, features = [
   "RtcSessionDescription",
   "RtcSessionDescriptionInit",
 ] }
-local-channel = "0.1.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-webrtc = "0.10"
-trait-variant = "0.1.2"
-flume = { version = "0.11.0", default-features = false, features = ["async"] }
+webrtc = "0.11"
+trait-variant = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 pretty_env_logger = "0.5"
 tokio = { version = "1.36", features = ["rt", "macros"] }
-wasm-bindgen-test = "0.3.42"
+wasm-bindgen-test = "0.3"
 console_log = "1.0"

--- a/crates/just-webrtc/README.md
+++ b/crates/just-webrtc/README.md
@@ -125,4 +125,5 @@ async fn run_remote_peer(offer: SessionDescription, candidates: Vec<ICECandidate
 This project is licensed under either of
 * [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 * [MIT License](https://opensource.org/licenses/MIT)
+
 at your option.

--- a/crates/just-webrtc/src/lib.rs
+++ b/crates/just-webrtc/src/lib.rs
@@ -10,7 +10,10 @@ pub mod types;
 use bytes::Bytes;
 use platform::{Channel, Error, PeerConnection, Platform};
 use std::marker::PhantomData;
-use types::{DataChannelOptions, ICECandidate, ICEServer, PeerConfiguration, PeerConnectionState, SessionDescription};
+use types::{
+    DataChannelOptions, ICECandidate, ICEServer, PeerConfiguration, PeerConnectionState,
+    SessionDescription,
+};
 
 #[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 #[cfg_attr(target_arch = "wasm32", allow(async_fn_in_trait))]

--- a/crates/just-webrtc/src/lib.rs
+++ b/crates/just-webrtc/src/lib.rs
@@ -4,15 +4,13 @@
 #![warn(dead_code)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use std::marker::PhantomData;
-
-use bytes::Bytes;
-
 pub mod platform;
 pub mod types;
 
+use bytes::Bytes;
 use platform::{Channel, Error, PeerConnection, Platform};
-use types::{DataChannelOptions, ICECandidate, ICEServer, PeerConfiguration, SessionDescription};
+use std::marker::PhantomData;
+use types::{DataChannelOptions, ICECandidate, ICEServer, PeerConfiguration, PeerConnectionState, SessionDescription};
 
 #[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 #[cfg_attr(target_arch = "wasm32", allow(async_fn_in_trait))]
@@ -21,7 +19,7 @@ pub trait DataChannelExt {
     /// Wait for the data channel to become open and ready to transfer data
     async fn wait_ready(&self);
     /// Receive data from the channel
-    async fn receive(&mut self) -> Result<Bytes, Error>;
+    async fn receive(&self) -> Result<Bytes, Error>;
     /// Send data to the channel
     async fn send(&self, data: &Bytes) -> Result<usize, Error>;
     /// Get the unique ID of the channel
@@ -34,12 +32,12 @@ pub trait DataChannelExt {
 #[cfg_attr(target_arch = "wasm32", allow(async_fn_in_trait))]
 /// **Platform agnostic WebRTC PeerConnection API**
 pub trait PeerConnectionExt {
-    /// Wait for the peer connection to become connected
-    async fn wait_peer_connected(&self);
+    /// Await change in the peer connection state
+    async fn state_change(&self) -> PeerConnectionState;
     /// Receive a data channel from the peer connection
-    async fn receive_channel(&mut self) -> Result<Channel, Error>;
+    async fn receive_channel(&self) -> Result<Channel, Error>;
     /// Collect all ICE candidates from the peer connection
-    async fn collect_ice_candidates(&mut self) -> Result<Vec<ICECandidate>, Error>;
+    async fn collect_ice_candidates(&self) -> Result<Vec<ICECandidate>, Error>;
     /// Get the local `SessionDescription` of the peer connection
     async fn get_local_description(&self) -> Option<SessionDescription>;
     /// Add remote ICE candidates to the peer connection

--- a/crates/just-webrtc/src/platform/native.rs
+++ b/crates/just-webrtc/src/platform/native.rs
@@ -1,9 +1,11 @@
 //! Native WebRTC implementation using `webrtc-rs`
 
-use crate::{Platform, DataChannelExt, DataChannelOptions, PeerConnectionBuilder, PeerConnectionExt};
 use crate::types::{
     BundlePolicy, ICECandidate, ICECredentialType, ICEServer, ICETransportPolicy,
     PeerConfiguration, PeerConnectionState, RTCPMuxPolicy, SDPType, SessionDescription,
+};
+use crate::{
+    DataChannelExt, DataChannelOptions, PeerConnectionBuilder, PeerConnectionExt, Platform,
 };
 use async_cell::sync::AsyncCell;
 use bytes::Bytes;
@@ -13,8 +15,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use webrtc::api::APIBuilder;
 use webrtc::data_channel::{
-    data_channel_init::RTCDataChannelInit, data_channel_message::DataChannelMessage,
-    RTCDataChannel,
+    data_channel_init::RTCDataChannelInit, data_channel_message::DataChannelMessage, RTCDataChannel,
 };
 use webrtc::ice_transport::{
     ice_candidate::{RTCIceCandidate, RTCIceCandidateInit},
@@ -23,17 +24,16 @@ use webrtc::ice_transport::{
     ice_gatherer_state::RTCIceGathererState,
     ice_server::RTCIceServer,
 };
-use webrtc::peer_connection::{
-    configuration::RTCConfiguration,
-    peer_connection_state::RTCPeerConnectionState,
-    RTCPeerConnection,
-};
 use webrtc::peer_connection::policy::{
     bundle_policy::RTCBundlePolicy, ice_transport_policy::RTCIceTransportPolicy,
     rtcp_mux_policy::RTCRtcpMuxPolicy,
 };
 use webrtc::peer_connection::sdp::{
-    sdp_type::RTCSdpType, session_description::RTCSessionDescription
+    sdp_type::RTCSdpType, session_description::RTCSessionDescription,
+};
+use webrtc::peer_connection::{
+    configuration::RTCConfiguration, peer_connection_state::RTCPeerConnectionState,
+    RTCPeerConnection,
 };
 
 /// Native platform marker

--- a/crates/just-webrtc/src/platform/wasm.rs
+++ b/crates/just-webrtc/src/platform/wasm.rs
@@ -1,14 +1,14 @@
 //! Wasm WebRTC implementation using `web_sys`
 
-use crate::{Platform, DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
 use crate::types::{
-        BundlePolicy, ICECandidate, ICETransportPolicy, PeerConnectionState, SDPType,
-        SessionDescription,
+    BundlePolicy, ICECandidate, ICETransportPolicy, PeerConnectionState, SDPType,
+    SessionDescription,
 };
+use crate::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt, Platform};
 use async_cell::unsync::AsyncCell;
 use bytes::Bytes;
-use js_sys::{Function, Reflect};
 use flume::{Receiver, RecvError, Sender};
+use js_sys::{Function, Reflect};
 use log::{debug, error, trace};
 use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, convert::FromWasmAbi, JsCast, JsValue};

--- a/crates/just-webrtc/tests/data_channels.rs
+++ b/crates/just-webrtc/tests/data_channels.rs
@@ -1,16 +1,14 @@
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
+use just_webrtc::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
+use just_webrtc::types::{DataChannelOptions, PeerConnectionState};
 use log::debug;
-
-use just_webrtc::{
-    types::DataChannelOptions, DataChannelExt, PeerConnectionBuilder, PeerConnectionExt,
-};
 
 async fn test_data_channel() -> Result<()> {
     // create local peer connection from channel options
     debug!("create local peer connection");
     let channel_options = vec![(format!("test_channel_"), DataChannelOptions::default())];
-    let mut local_peer_connection = PeerConnectionBuilder::new()
+    let local_peer_connection = PeerConnectionBuilder::new()
         .with_channel_options(channel_options)?
         .build()
         .await?;
@@ -25,7 +23,7 @@ async fn test_data_channel() -> Result<()> {
 
     // create remote peer connection from received offer and candidates
     debug!("create remote peer connection");
-    let mut remote_peer_connection = PeerConnectionBuilder::new()
+    let remote_peer_connection = PeerConnectionBuilder::new()
         .with_remote_offer(Some(offer))?
         .build()
         .await?;
@@ -47,12 +45,12 @@ async fn test_data_channel() -> Result<()> {
     local_peer_connection.add_ice_candidates(candidates).await?;
     // wait for local and remote peers to connect
     debug!("wait for local and remote peers to connect");
-    local_peer_connection.wait_peer_connected().await;
-    remote_peer_connection.wait_peer_connected().await;
+    while local_peer_connection.state_change().await != PeerConnectionState::Connected {}
+    while remote_peer_connection.state_change().await != PeerConnectionState::Connected {}
     // receive data channel from local and remote peers
     debug!("receive data channel from local and remote peers");
-    let mut local_channel = local_peer_connection.receive_channel().await.unwrap();
-    let mut remote_channel = remote_peer_connection.receive_channel().await.unwrap();
+    let local_channel = local_peer_connection.receive_channel().await.unwrap();
+    let remote_channel = remote_peer_connection.receive_channel().await.unwrap();
     // wait for data channels to be ready
     debug!("wait for data channels to be ready");
     local_channel.wait_ready().await;

--- a/crates/just-webrtc/tests/data_channels.rs
+++ b/crates/just-webrtc/tests/data_channels.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
-use just_webrtc::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
 use just_webrtc::types::{DataChannelOptions, PeerConnectionState};
+use just_webrtc::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
 use log::debug;
 
 async fn test_data_channel() -> Result<()> {

--- a/examples/signalling-peer/Cargo.toml
+++ b/examples/signalling-peer/Cargo.toml
@@ -10,13 +10,13 @@ anyhow = "1.0"
 just-webrtc = { path = "../../crates/just-webrtc" }
 just-webrtc-signalling = { path = "../../crates/just-webrtc-signalling", default-features = false, features = ["client"] }
 log = "0.4"
-futures-util = "0.3.30"
-zduny-wasm-timer = "0.2.8"
+futures-util = "0.3"
+zduny-wasm-timer = "0.2"
 bincode = "1.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_log = "1.0"
-wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-futures = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pretty_env_logger = "0.5"

--- a/examples/signalling-peer/README.md
+++ b/examples/signalling-peer/README.md
@@ -23,6 +23,8 @@ Serve the binary via trunk and open the provided URL in your browser!
 
 To see the messages bouncing between peers, open the browser's developer console.
 
+NOTE: Depending on the browser and operating system, it is sometimes difficult to test local communications between two tabs. The most reliable combination for local testing I have found is between two firefox tabs, where one is in private browsing mode.
+
 ```sh
 # install protobuf compiler
 apt install -y protobuf-compiler

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -1,31 +1,27 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc, time::Duration};
-
 use anyhow::{anyhow, Result};
-use futures_util::StreamExt;
-use log::info;
-
-use just_webrtc::{
-    platform::PeerConnection,
-    types::{DataChannelOptions, ICECandidate, SessionDescription},
-    DataChannelExt, PeerConnectionBuilder, PeerConnectionExt,
-};
+use futures_util::{pin_mut, select, FutureExt, StreamExt};
+use futures_util::future::{FusedFuture, Fuse};
+use just_webrtc::platform::{Channel, PeerConnection};
+use just_webrtc::types::{DataChannelOptions, ICECandidate, PeerConnectionState, SessionDescription};
+use just_webrtc::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
 use just_webrtc_signalling::client::RtcSignallingClientBuilder;
+use log::{error, info, warn};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::time::Duration;
 
 const ECHO_REQUEST: &str = "I'm literally Ryan Gosling.";
 const ECHO_RESPONSE: &str = "I know right! He's literally me.";
+const ECHO_PERIOD: Duration = Duration::from_millis(1000);
+const CONNECTION_DROP_TIMEOUT: Duration = Duration::from_secs(15);
 
-async fn peer_echo_task(remote_id: u64, mut peer_connection: PeerConnection) -> Result<u64> {
-    info!("started peer echo task. ({remote_id})");
-    // take peer connection from the map
-    peer_connection.wait_peer_connected().await;
-    let mut channel = peer_connection.receive_channel().await.unwrap();
-    channel.wait_ready().await;
-    // prepare echo request/response
+async fn channel_echo_task(offerer: bool, channel: Channel) -> Result<()> {
     let channel_fmt = format!("{}:{}", channel.label(), channel.id());
     // if offerer, we send echo requests, otherwise we listen for requests
-    if peer_connection.is_offerer() {
+    if offerer {
         let echo_request = bincode::serialize(ECHO_REQUEST)?.into();
-        let mut interval = zduny_wasm_timer::Interval::new(Duration::from_secs(1));
+        let mut interval = zduny_wasm_timer::Interval::new(ECHO_PERIOD);
         loop {
             interval.next().await;
             // offerer makes echo requests
@@ -54,12 +50,72 @@ async fn peer_echo_task(remote_id: u64, mut peer_connection: PeerConnection) -> 
     }
 }
 
+async fn peer_echo_task(remote_id: &u64, peer_connection: PeerConnection) -> Result<()> {
+    info!("started peer echo task. ({remote_id})");
+    let state_change_fut = peer_connection.state_change().fuse();
+    let channel_ready_fut = Fuse::terminated();
+    let channel_task_fut = Fuse::terminated();
+    let connection_drop_timeout_fut = Fuse::terminated();
+    pin_mut!(state_change_fut, channel_task_fut, channel_ready_fut, connection_drop_timeout_fut);
+    // peer connection monitoring loop
+    // in this example we use the futures crate select! macro as a runtime agnostic method
+    // for concurrently monitoring peer connection state and running a single channel task.
+    loop {
+        select! {
+            state = state_change_fut => {
+                state_change_fut.set(peer_connection.state_change().fuse());
+                match state {
+                    PeerConnectionState::New |
+                    PeerConnectionState::Connected => {
+                        // clear the timeout fut
+                        if !connection_drop_timeout_fut.is_terminated() {
+                            info!("peer connection recovered! ({remote_id})");
+                            connection_drop_timeout_fut.set(Fuse::terminated());
+                        } else {
+                            info!("peer connected. ({remote_id})");
+                            let channel = peer_connection.receive_channel().await.unwrap();
+                            let offerer = peer_connection.is_offerer();
+                            channel_ready_fut.set(async move {
+                                channel.wait_ready().await;
+                                (channel, offerer)
+                            }.fuse());
+                        }
+                    },
+                    PeerConnectionState::Disconnected => {
+                        warn!("peer connection interrupted. attempting to recover... ({remote_id})");
+                        let timeout = zduny_wasm_timer::Delay::new(CONNECTION_DROP_TIMEOUT);
+                        connection_drop_timeout_fut.set(timeout.fuse());
+                    },
+                    PeerConnectionState::Failed => {
+                        error!("peer connection failed! ({remote_id})");
+                        return Ok(())
+                    }
+                    PeerConnectionState::Closed => {
+                        info!("peer connection closed! ({remote_id})");
+                        return Ok(())
+                    }
+                    _ => {},
+                }
+            },
+            (channel, offerer) = channel_ready_fut => {
+                channel_task_fut.set(channel_echo_task(offerer, channel).fuse());
+            }
+            result = channel_task_fut => result?,
+            result = connection_drop_timeout_fut => {
+                result?;
+                error!("timeout waiting for connection to re-establish. ({remote_id})");
+                return Ok(())
+            },
+        }
+    }
+}
+
 async fn create_offer() -> Result<((SessionDescription, Vec<ICECandidate>), PeerConnection)> {
     let channel_options = vec![(
         "example_channel_".to_string(),
         DataChannelOptions::default(),
     )];
-    let mut local_peer_connection = PeerConnectionBuilder::new()
+    let local_peer_connection = PeerConnectionBuilder::new()
         .with_channel_options(channel_options)?
         .build()
         .await?;
@@ -75,7 +131,7 @@ async fn receive_offer(
     offer: SessionDescription,
     candidates: Vec<ICECandidate>,
 ) -> Result<((SessionDescription, Vec<ICECandidate>), PeerConnection)> {
-    let mut remote_peer_connection = PeerConnectionBuilder::new()
+    let remote_peer_connection = PeerConnectionBuilder::new()
         .with_remote_offer(Some(offer))?
         .build()
         .await?;
@@ -147,6 +203,7 @@ async fn run_peer(addr: &str) -> Result<()> {
         let peer_connections = peer_connections_offer.clone();
         async move {
             let (offer_set, local_peer_connection) = create_offer().await?;
+            // add local peer connection to the map
             peer_connections
                 .borrow_mut()
                 .insert(remote_id, local_peer_connection)?;
@@ -158,6 +215,7 @@ async fn run_peer(addr: &str) -> Result<()> {
     let receive_answer_fn = move |remote_id, (answer, candidates)| {
         let peer_connections = peer_connections_answer.clone();
         async move {
+            // take peer connection from the map
             let peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
             receive_answer(answer, candidates, &peer_connection).await?;
             peer_connections
@@ -171,8 +229,10 @@ async fn run_peer(addr: &str) -> Result<()> {
     let local_sig_cplt_fn = move |remote_id| {
         let peer_connections = peer_connections_local.clone();
         async move {
+            // take peer connection from the map
             let local_peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
-            peer_echo_task(remote_id, local_peer_connection).await
+            peer_echo_task(&remote_id, local_peer_connection).await?;
+            Ok::<_, anyhow::Error>(remote_id)
         }
     };
     // prepare receive offer callback closure
@@ -181,6 +241,7 @@ async fn run_peer(addr: &str) -> Result<()> {
         let peer_connections = peer_connections_offer.clone();
         async move {
             let (answer_set, remote_peer_connection) = receive_offer(offer, candidates).await?;
+            // add remote peer connection to the map
             peer_connections
                 .borrow_mut()
                 .insert(remote_id, remote_peer_connection)?;
@@ -193,7 +254,8 @@ async fn run_peer(addr: &str) -> Result<()> {
         let peer_connections = peer_connections_remote.clone();
         async move {
             let remote_peer_connection = peer_connections.borrow_mut().take(&remote_id)?;
-            peer_echo_task(remote_id, remote_peer_connection).await
+            peer_echo_task(&remote_id, remote_peer_connection).await?;
+            Ok::<_, anyhow::Error>(remote_id)
         }
     };
 

--- a/examples/signalling-peer/src/main.rs
+++ b/examples/signalling-peer/src/main.rs
@@ -1,8 +1,10 @@
 use anyhow::{anyhow, Result};
+use futures_util::future::{Fuse, FusedFuture};
 use futures_util::{pin_mut, select, FutureExt, StreamExt};
-use futures_util::future::{FusedFuture, Fuse};
 use just_webrtc::platform::{Channel, PeerConnection};
-use just_webrtc::types::{DataChannelOptions, ICECandidate, PeerConnectionState, SessionDescription};
+use just_webrtc::types::{
+    DataChannelOptions, ICECandidate, PeerConnectionState, SessionDescription,
+};
 use just_webrtc::{DataChannelExt, PeerConnectionBuilder, PeerConnectionExt};
 use just_webrtc_signalling::client::RtcSignallingClientBuilder;
 use log::{error, info, warn};
@@ -56,7 +58,12 @@ async fn peer_echo_task(remote_id: &u64, peer_connection: PeerConnection) -> Res
     let channel_ready_fut = Fuse::terminated();
     let channel_task_fut = Fuse::terminated();
     let connection_drop_timeout_fut = Fuse::terminated();
-    pin_mut!(state_change_fut, channel_task_fut, channel_ready_fut, connection_drop_timeout_fut);
+    pin_mut!(
+        state_change_fut,
+        channel_task_fut,
+        channel_ready_fut,
+        connection_drop_timeout_fut
+    );
     // peer connection monitoring loop
     // in this example we use the futures crate select! macro as a runtime agnostic method
     // for concurrently monitoring peer connection state and running a single channel task.

--- a/examples/signalling-server/src/main.rs
+++ b/examples/signalling-server/src/main.rs
@@ -1,9 +1,6 @@
-use std::{sync::Arc, time::Duration};
-
 use anyhow::Result;
-use just_webrtc_signalling::{
-    server::Signalling, DEFAULT_NATIVE_SERVER_ADDR, DEFAULT_WEB_SERVER_ADDR,
-};
+use just_webrtc_signalling::{server::Signalling, DEFAULT_NATIVE_SERVER_ADDR, DEFAULT_WEB_SERVER_ADDR};
+use std::{sync::Arc, time::Duration};
 
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 

--- a/examples/signalling-server/src/main.rs
+++ b/examples/signalling-server/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use just_webrtc_signalling::{server::Signalling, DEFAULT_NATIVE_SERVER_ADDR, DEFAULT_WEB_SERVER_ADDR};
+use just_webrtc_signalling::{
+    server::Signalling, DEFAULT_NATIVE_SERVER_ADDR, DEFAULT_WEB_SERVER_ADDR,
+};
 use std::{sync::Arc, time::Duration};
 
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);


### PR DESCRIPTION
* Adds a new async `state_change` method to the `PeerConnectionExt` trait. This method can be awaited to receive WebRTC state changes and act accordingly (Closes #3).
* Several trait methods now only require an immutable borrow thanks to use of flume across both native and web.
* Updated dependencies to latest versions, and removed patch version specifications.
* Updated `signalling-peer` example to use new `state_change` method to implement a single-threaded concurrent task for connection monitoring and recovery.

